### PR TITLE
Add optional key argument to add-profiling!.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ It's also possible to add profiling to pre-defined functions:
 
 This will profile the function `foo` whenever it is invoked. The
 resulting measurement will be stored under the fully qualified name of
-the function; in this case, `:user/foo`.
+the function; in this case, `:user/foo`. An optional second argument
+to `add-profiling!` can be used to name the measurement key
+differently.
 
 Finally, Measure provides a way of adding data to any measurements
 taken within a block.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject listora/measure "0.1.2"
+(defproject listora/measure "0.1.3-SNAPSHOT"
   :description "A profiling and metrics library"
   :url "https://github.com/listora/measure"
   :license {:name "Eclipse Public License"

--- a/src/listora/measure.clj
+++ b/src/listora/measure.clj
@@ -47,10 +47,14 @@
   [key & body]
   `(profile* ~key (^:once fn* [] ~@body)))
 
+(defn- default-key [var]
+  (keyword (-> var .ns .name str)
+           (-> var .sym str)))
+
 (defn add-profiling!
   "Add profiling to a function defined in a var."
-  [var]
-  (let [ns  (-> var .ns .name str)
-        sym (-> var .sym str)
-        key (keyword ns sym)]
-    (alter-var-root var (fn [f] (fn [& args] (profile* key #(apply f args)))))))
+  ([var]
+     (add-profiling! var (default-key var)))
+  ([var key]
+     (alter-var-root
+      var (fn [f] (fn [& args] (profile* key #(apply f args)))))))

--- a/test/listora/measure_test.clj
+++ b/test/listora/measure_test.clj
@@ -54,7 +54,7 @@
     (is (< (-> m :foo :elapsed) 0.1))
     (is (> (-> m :foo :elapsed) 0.0))))
 
-(deftest test-add-profiling!
+(deftest test-add-profiling-of-time-elapsed
   (defn add-two [x] (+ x 2))
   (try
     (add-profiling! #'add-two)
@@ -67,6 +67,25 @@
       (is (number? (-> m :listora.measure-test/add-two :elapsed)))
       (is (< (-> m :listora.measure-test/add-two :elapsed) 0.1))
       (is (> (-> m :listora.measure-test/add-two :elapsed) 0.0)))
-    
+
     (finally
       (ns-unmap *ns* 'add-two))))
+
+(deftest test-add-profiling-measurement-keys
+  (testing "with no explicit key"
+    (try
+      (defn add-two [x] (+ x 2))
+      (add-profiling! #'add-two)
+      (is (= (add-two 3) 5))
+      (is (contains? (<!! measurements) :listora.measure-test/add-two))
+      (finally
+        (ns-unmap *ns* 'add-three))))
+
+  (testing "with a key of :my-metric"
+    (try
+      (defn add-two [x] (+ x 2))
+      (add-profiling! #'add-two :custom)
+      (is (= (add-two 3) 5))
+      (is (contains? (<!! measurements) :custom))
+      (finally
+        (ns-unmap *ns* 'add-three)))))


### PR DESCRIPTION
This adds the option to profile a fn via a different logging key, and
not the default namespace.fn-name key.
